### PR TITLE
changes irma-core to v0.5.1 to fix polyg trimming bug

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -113,7 +113,7 @@ process {
         ]
     }
 
-        withName: 'FLUTRIMPRIMERS' {
+    withName: 'FLUTRIMPRIMERS' {
 
         publishDir = [
             path: { "${params.outdir}/${sample}/primer-trimmed-reads" },

--- a/conf/modules_docker.config
+++ b/conf/modules_docker.config
@@ -114,7 +114,7 @@ process {
         ]
     }
 
-        withName: 'FLUTRIMPRIMERS' {
+    withName: 'FLUTRIMPRIMERS' {
 
         publishDir = [
             path: { "${params.outdir}/${sample}/primer-trimmed-reads" },

--- a/conf/omics.config
+++ b/conf/omics.config
@@ -122,7 +122,7 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        container = 'ghcr.io/cdcgov/irma-core:v0.4.3'
+        container = 'ghcr.io/cdcgov/irma-core:v0.5.1'
     }
 
 
@@ -134,7 +134,7 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        container = 'ghcr.io/cdcgov/irma-core:v0.4.3'
+        container = 'ghcr.io/cdcgov/irma-core:v0.5.1'
     }
 
     withName: 'RSVTRIMPRIMERS' {
@@ -145,7 +145,18 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        container = 'ghcr.io/cdcgov/irma-core:v0.4.3'
+        container = 'ghcr.io/cdcgov/irma-core:v0.5.1'
+    }
+
+    withName: 'FLUTRIMPRIMERS' {
+
+        publishDir = [
+            path: { "${params.outdir}/${sample}/primer-trimmed-reads" },
+            pattern: '*',
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        container = 'ghcr.io/cdcgov/irma-core:v0.5.1'
     }
 
     withName: 'IRMA' {

--- a/modules/local/flutrimprimers.nf
+++ b/modules/local/flutrimprimers.nf
@@ -2,7 +2,7 @@ process FLUTRIMPRIMERS {
     tag "${sample}"
     label 'process_medium'
 
-    container 'ghcr.io/cdcgov/irma-core:v0.4.3'
+    container 'ghcr.io/cdcgov/irma-core:v0.5.1'
 
     input:
     tuple val(sample), path(subsampled_fastq_1), path(subsampled_fastq_2), path(primers), val(primer_kmer_len), val(primer_restrict_window)

--- a/modules/local/rsvtrimprimers.nf
+++ b/modules/local/rsvtrimprimers.nf
@@ -2,7 +2,7 @@ process RSVTRIMPRIMERS {
     tag "${sample}"
     label 'process_medium'
 
-    container 'ghcr.io/cdcgov/irma-core:v0.4.3'
+    container 'ghcr.io/cdcgov/irma-core:v0.5.1'
 
     input:
     tuple val(sample), path(subsampled_fastq_1), path(subsampled_fastq_2), path(primers), val(primer_kmer_len), val(primer_restrict_window)

--- a/modules/local/sc2trimprimers.nf
+++ b/modules/local/sc2trimprimers.nf
@@ -2,7 +2,7 @@ process SC2TRIMPRIMERS {
     tag "${sample}"
     label 'process_medium'
 
-    container 'ghcr.io/cdcgov/irma-core:v0.4.3'
+    container 'ghcr.io/cdcgov/irma-core:v0.5.1'
 
     input:
     tuple val(sample), path(subsampled_fastq_1), path(subsampled_fastq_2), path(primers), val(primer_kmer_len), val(primer_restrict_window)

--- a/modules/local/trimbarcodes.nf
+++ b/modules/local/trimbarcodes.nf
@@ -2,7 +2,7 @@ process TRIMBARCODES {
     tag "${sample}"
     label 'process_medium'
 
-    container 'ghcr.io/cdcgov/irma-core:v0.4.3'
+    container 'ghcr.io/cdcgov/irma-core:v0.5.1'
 
     input:
     tuple val(sample), val(barcode), path(subsample_file_path), val(seq)


### PR DESCRIPTION
Updates container for irma-core to v0.5.1 to fix polyg trimming bug in `trimbarcodes.nf`, `rsvtrimprimers.nf`, `sc2trimprimers.nf`, `flutrimprimers.nf`; 
updated `omics.config` to include `flutrimprimers` and correct container versions.