### PR TITLE
mention v2 benchmarks in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | rsv_b          | 2025-09-09--12-13-13Z |
 | sars-cov-2     | 2026-01-06--14-59-32Z |
 
-### Enhancements
+### `Enhancements`
+
+- The v2.0.0 release of MIRA-NF saw a reduction in dependencies as well as multiple optimizations to the pipeline and steps within, leading to significant improvements in runtime and memory usage. See [benchmark details](https://github.com/CDCgov/MIRA-NF/issues/138).
 
 ### `Added`
 


### PR DESCRIPTION
Adds mention and link to v2.0.0 benchmarks in the changelog under `Enhancements` heading.
