### PR TITLE
Use 6 output files for DAIS-ribosome

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -223,7 +223,7 @@ Coverage figure created by IRMA
 
 - `aggregate_outputs/dais-ribosome/`
   - DAIS_ribosome_input.fasta - input fasta files that is used as the input for DAIS-ribosome
-  - DAIS_ribosome.in - file contains the insertion found in all the samples assembled by IRMA
+  - DAIS_ribosome.ins - file contains the insertion found in all the samples assembled by IRMA
   - DAIS_ribosome.del - file contains the deletions found in all the samples assembled by IRMA
   - DAIS_ribosome.seq - file contains sequence related data from all the samples assembled by IRMA
 

--- a/modules/local/daisribosome.nf
+++ b/modules/local/daisribosome.nf
@@ -9,7 +9,7 @@ process DAISRIBOSOME {
     val dais_module
 
     output:
-    path('*.{seq,gen,ins,del}') , emit: dais_outputs
+    path('*.{seq,ins,del,gen_seq,gen_ins,gen_del}') , emit: dais_outputs
     path('*.seq') , emit: dais_seq_output
     path 'versions.yml' , emit: versions
 
@@ -17,7 +17,7 @@ process DAISRIBOSOME {
     '''
     base_name=$(basename !{input_fasta})
     dais_out="${base_name%_input*}"
-    ribosome --module !{dais_module} !{input_fasta} ${dais_out}.seq ${dais_out}.ins ${dais_out}.del ${dais_out}.gen
+    ribosome --module !{dais_module} !{input_fasta} ${dais_out}.seq ${dais_out}.ins ${dais_out}.del ${dais_out}.gen_seq ${dais_out}.gen_ins ${dais_out}.gen_del
 
     echo "!{task.process}: daisribosome: cdcgov/dais-ribosome:v2.1.0" > versions.yml
     '''


### PR DESCRIPTION
<!--
# mira-nf/mira pull request

Many thanks for contributing to mira-nf/mira!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/mira-nf/mira/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/CDCgov/MIRA-NF/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


This PR is updating the DAIS-ribosome outputs to explicitly specify the 6 output files, rather than specifying a prefix for the genome outputs which is now deprecated and will soon be removed.